### PR TITLE
Update base code for Recast v2 API

### DIFF
--- a/examples/recast-bot.js
+++ b/examples/recast-bot.js
@@ -48,13 +48,13 @@ app.use(recast.middleware())
 
 // Intent handler
 recast.on('termostat', (ctx) => {
-  // First sentence
-  const sentence = ctx.state.recast.sentence
+  // Entities
+  const entities = ctx.state.recast.entities
 
   // Get first room / temperature entity
-  const room = sentence.entities.room && sentence.entities.room[0]
-  const temperature = sentence.entities.temperature && sentence.entities.temperature[0]
-  switch (sentence.type) {
+  const room = entities.room && entities.room[0]
+  const temperature = entities.temperature && entities.temperature[0]
+  switch (ctx.state.recast.act) {
     // Handle command
     case 'command':
     case 'assert':

--- a/lib/telegraf-recast.js
+++ b/lib/telegraf-recast.js
@@ -60,6 +60,10 @@ class RecastContext {
   get timestamp () {
     return this.data.timestamp
   }
+  
+  get act() {
+		return this.data.act;
+	}
 
   get intent () {
     return this.intents[0]

--- a/lib/telegraf-recast.js
+++ b/lib/telegraf-recast.js
@@ -15,7 +15,7 @@ class RecastAi extends Router {
           }
           const context = new RecastContext(response.results)
           return Promise.resolve({
-            route: context.intent,
+            route: context.intent.slug,
             state: {
               recast: context
             }
@@ -27,7 +27,7 @@ class RecastAi extends Router {
 
   request (message) {
     debug('request', message)
-    return fetch('https://api.recast.ai/v1/request', {
+    return fetch('https://api.recast.ai/v2/request', {
       method: 'POST',
       headers: {
         'Authorization': `Token ${this.token}`,
@@ -69,13 +69,13 @@ class RecastContext {
     return this.data.intents || []
   }
 
-  get sentence () {
-    return this.sentences[0]
-  }
+  get entities() {
+		return this.data.entities || {};
+	}
 
-  get sentences () {
-    return this.data.sentences || []
-  }
+	get source() {
+		return this.source;
+	}
 }
 
 module.exports = RecastAi

--- a/readme.md
+++ b/readme.md
@@ -72,8 +72,8 @@ recast.on('intent name', (ctx) => {
   ctx.state.recast            // Current RecastAI context 
   ctx.state.recast.intent     // first intent
   ctx.state.recast.intents    // intents
-  ctx.state.recast.sentence   // first sentence
-  ctx.state.recast.sentences  // sentences
+  ctx.state.recast.source     // original text
+  ctx.state.recast.entities   // entities
   ctx.state.recast.raw        // raw recast.ai response
 })
 ```

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Telegraf user context props and functions:
 ```js
 recast.on('intent name', (ctx) => {
   ctx.state.recast            // Current RecastAI context 
+  ctx.state.recast.act        // type of text
   ctx.state.recast.intent     // first intent
   ctx.state.recast.intents    // intents
   ctx.state.recast.source     // original text


### PR DESCRIPTION
Updated the requests to run through v2 of Recast's API (v1 is now defunct).

Updated the example code for a few of the methods that have been changed with the new API.